### PR TITLE
Fix slash direction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We are still in the early stages of development. JeffBot was originally supposed
 You will need a copy of PostgreSQL, RabbitMQ, and two terminals. Simply edit the `development` portion of each file in the `config` directory. After that, run both `ruby ./frontend/main.rb` and `ruby ./backend/main.rb`. You may need to set the environment variable `RABBITMQ_BIGWIG_URL` to point to your RabbitMQ installation (for localhost, use `ampq:\\localhost`).
 
 ## What if I'm too lazy to run it locally?
-We have an installation running on heroku. You can visit it by going to [https:\\jeffchatbot.herokuapp.com](https:\\jeffchatbot.herokuapp.com). There is also a [GroupMe group](https://groupme.com/join_group/21478794/zYbvId), and an upcoming Kik version coming soon.
+We have an installation running on heroku. You can visit it by going to [https://jeffchatbot.herokuapp.com](https://jeffchatbot.herokuapp.com). There is also a [GroupMe group](https://groupme.com/join_group/21478794/zYbvId), and an upcoming Kik version coming soon.
 
 ## Can I help?
 Sure! Just be sure to document your code and your PRs. Remember to submit your PR against the `dev` branch, otherwise your request will be denied. You are responsible for testing your code before submitting. Other than that, remember to keep it simple!


### PR DESCRIPTION
The README.md file lists `https:\\jeffchatbott.herokuapp.com` instead of `https://jeffchatbot.herokuapp.com`
