### PR TITLE
Use bootstraps secure CDN

### DIFF
--- a/frontend/views/layout.slim
+++ b/frontend/views/layout.slim
@@ -11,7 +11,7 @@
 
     <title>JeffBot</title>
 
-    <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
     <link href="src/css/chathome.css" rel="stylesheet">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular.min.js"></script>


### PR DESCRIPTION
This will use the `https` over the `http` protocol from bootstrap's CDN. Preventing `Mixed  Content` warnings & errors.
