### PR TITLE
Single Word Bug

### DIFF
--- a/app/lib/formulator.rb
+++ b/app/lib/formulator.rb
@@ -1,27 +1,24 @@
 require_relative 'wordchain'
 
 module Formulator
-    def Formulator.create_sentence(length, subject)
-        result = ""
-        previous_token = ""
-        iterator = 0
-        while (length > iterator)
-            if iterator == 0
-                result = subject + " "
-                previous_token = subject
-            else
-                token = WordChain.next_word(previous_token)
-                if token.eql?("")
-                    break
-                end
-                previous_token = token
-                result = result + token + " "
-            end
-            iterator = iterator + 1
-        end
-        return result.strip
+  def Formulator.create_sentence(length, subject)
+    iterator = 0
+    result = []
+    result << subject.chomp
+    previous_token = subject
+    token = WordChain.bigram_word(previous_token)
+    for _ in 0..length
+      break if token.eql?("") || token.eql?(nil) || iterator > length
+      result << token.chomp
+      earlier_token = previous_token
+      previous_token = token
+      token = WordChain.next_word([earlier_token, previous_token])
     end
-    def Formulator.create_sentence_random(subject)
-        return Formulator.create_sentence(3 + rand(8), subject)
-    end
+
+    result.join(' ')
+  end
+
+  def Formulator.create_sentence_random(subject)
+    return Formulator.create_sentence(3 + rand(8), subject)
+  end
 end

--- a/app/lib/formulator.rb
+++ b/app/lib/formulator.rb
@@ -7,15 +7,20 @@ module Formulator
     result << subject.chomp
     previous_token = subject
     token = WordChain.bigram_word(previous_token)
-    for _ in 0..length
-      break if token.eql?("") || token.eql?(nil) || iterator > length
+    for _ in 0..length*5
+      break if token.blank?
       result << token.chomp
       earlier_token = previous_token
       previous_token = token
       token = WordChain.next_word([earlier_token, previous_token])
+      if token.blank? || ([false]*5+[true]).sample
+        break if [true, false, false].sample
+        token = WordChain.bigram_word(previous_token)
+      end
     end
 
-    result.join(' ')
+    result[0] = result[0].titleize
+    "#{result.join(' ')}."
   end
 
   def Formulator.create_sentence_random(subject)

--- a/app/lib/wordchain.rb
+++ b/app/lib/wordchain.rb
@@ -1,34 +1,24 @@
 require 'active_record'
 require_relative '../models/entries'
 
-module WordChain
-    def WordChain.next_word(previous_tokens)
-        groups = Entries.where(word: previous_tokens[0], nword: previous_tokens[1]).order(count: :desc)
-        if(groups.length == 0)
-            return ""
-        else
-            tokens = Array.new
-            groups.each do |item|
-                for i in 0..item.count
-                    tokens.push(item.definition)
-                end
-            end
-            return tokens[rand(tokens.length)]
-        end
-    end
+class WordChain
+  def self.next_word(previous_tokens)
+    tokens = Entries.where(word: previous_tokens[0], nword: previous_tokens[1]).order(count: :desc)
+    find_best_token(tokens)
+  end
 
-    def WordChain.bigram_word(previous_token)
-        groups = Entries.where(word: previous_token).order(count: :desc)
-        if(groups.length == 0)
-            return ""
-        else
-            tokens = Array.new
-            groups.each do |item|
-                for i in 0..item.count
-                    tokens.push(item.nword)
-                end
-            end
-            return tokens[rand(tokens.length)]
-        end
+  def self.bigram_word(previous_token)
+    tokens = Entries.where(word: previous_token).order(count: :desc)
+    find_best_token(tokens)
+  end
+
+  private
+  def self.find_best_token(tokens)
+    return "" if(tokens.length == 0)
+
+    tokens.map(&:definition).each do |token|
+      return token if rand < 0.9
     end
+    return tokens.last.definition
+  end
 end


### PR DESCRIPTION
# Problem

The new NGram/Wordchainer used strings as inputs and the new `WordChain.next_word` uses an array input.
# Solution

The solution is to call the correct method with the correct params.
